### PR TITLE
scripts: Shellcheck scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: ci
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+       scandir: './scripts'


### PR DESCRIPTION
Shellcheck all shell scripts in the scripts directory. Enforce passing
shellcheck on CI with GitHub action. Fix all shellcheck warnings and
error in scripts/k3s-killall.sh.