### PR TITLE
site: Add julia manifest

### DIFF
--- a/manifests/julia/cert-manager-issuers.yaml
+++ b/manifests/julia/cert-manager-issuers.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  namespace: cert-manager
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: me@juliaogris.com
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          ingress:
+            class: traefik
+        selector:
+          dnsZones:
+            - 'jul.run'
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  namespace: cert-manager
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: me@juliaogris.com
+    privateKeySecretRef:
+      name: letsencrypt-key
+    solvers:
+      - http01:
+          ingress:
+            class: traefik
+        selector:
+          dnsZones:
+            - 'jul.run'

--- a/manifests/julia/whoami-ingress-julrun.yaml
+++ b/manifests/julia/whoami-ingress-julrun.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: whoami
+  name: whoami-julrun
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    traefik.ingress.kubernetes.io/router.entrypoints: https
+spec:
+  tls:
+    - hosts:
+      - whoami.jul.run
+      secretName: whoami-julrun-https-cert
+  rules:
+    - host: whoami.jul.run
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: whoami
+                port:
+                  name: http

--- a/manifests/traefik/20_services.yaml
+++ b/manifests/traefik/20_services.yaml
@@ -32,3 +32,6 @@ spec:
     - name: https
       port: 443
       nodePort: 30443
+    - name: dashboard
+      port: 8080
+      nodePort: 30088


### PR DESCRIPTION
Copy most of camh's setup from `manifests/camh` to `manifests/julia`.
Add julia manifest for Julia's domain (jul.run) and email (me@juliaogris.com). 
Remove everything related to metallb - I couldn't get metallb and virtual
IPs to work on my Google WiFi home network.

Add the Traefik dashboard port to the NodePort Service so it can be
reached without a loadbalancer in `manifest/traefik`