### PR TITLE
traefik: Add http (unencrypted) entrypoint on port 8080

### DIFF
--- a/manifests/camh/traefik-services.yaml
+++ b/manifests/camh/traefik-services.yaml
@@ -36,6 +36,8 @@ spec:
     - name: https
       port: 443
       targetPort: 444
+    - name: http-no-redirect
+      port: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/traefik/20_services.yaml
+++ b/manifests/traefik/20_services.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 8080
+      targetPort: 9090
 ---
 apiVersion: v1
 kind: Service
@@ -33,5 +33,5 @@ spec:
       port: 443
       nodePort: 30443
     - name: dashboard
-      port: 8080
+      port: 9090
       nodePort: 30088

--- a/manifests/traefik/50_configmap.yaml
+++ b/manifests/traefik/50_configmap.yaml
@@ -15,17 +15,19 @@ data:
     log:
       level: 'INFO'
     entryPoints:
-      http:
+      traefik:  # Dashboard port
+        address: ':9090'
+      http:  # External http -> https redirect
         address: ':80'
         http:
           redirections:
             entryPoint:
               to: 'https'
-      https:
+      https:  # External https
         address: ':443'
         http:
           tls: {}
-      internal-http:
+      internal-http:  # Internal http -> https
         address: ':81'
         http:
           redirections:
@@ -35,7 +37,7 @@ data:
               # port 443, as internal and external are different LB
               # services.
               to: ':443'
-      internal-https:
+      internal-https:  # Internal https
         address: ':444'
         http:
           tls: {}

--- a/manifests/traefik/50_configmap.yaml
+++ b/manifests/traefik/50_configmap.yaml
@@ -41,6 +41,8 @@ data:
         address: ':444'
         http:
           tls: {}
+      internal-http-no-redirect:  # Internal http
+        address: ':8080'
     providers:
       kubernetesIngress: {}
       file:

--- a/manifests/traefik/60_deployment.yaml
+++ b/manifests/traefik/60_deployment.yaml
@@ -33,7 +33,7 @@ spec:
               containerPort: 443
             - name: traefik
               protocol: TCP
-              containerPort: 8080
+              containerPort: 9090
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
Add an additional ingress port of 8080 for http traffic that will not 
redirect to https. The prior setup had all http traffic (internal and 
external) be redirected to https. However some applications running on k8s
require http and not https - in this case it will be the unifi controller
that needs http for the devices to register with the controller. But other
IoT applications may need it due to the low power IoT devices out there
that may not be able to use https.

To do this, we need to move the dashboard to port 9090. This port is
only used internally, so nothing should notice this change. The services
that expose the dashboard do so on more standard ports (or a very
non-standard but unchanged node port).

Expose port 8080 on the internal load balancer service in camh's 
configuration. We don't want unencrypted traffic externally, but we can 
tolerate it internally.