### PR TITLE
traefik: Allow TLS to backends with unverified certs

### DIFF
--- a/manifests/traefik/50_configmap.yaml
+++ b/manifests/traefik/50_configmap.yaml
@@ -47,3 +47,5 @@ data:
       kubernetesIngress: {}
       file:
         directory: '/config'
+    serversTransport:
+      insecureSkipVerify: true


### PR DESCRIPTION
Enable the global `insecureSkipVerify` global setting in traefik that
means connections to backends via TLS do not need to have verifiable
certificates. This is not ideal, but usually we just use http
(unencrypted), so comparatively, this is not too bad.

This is needed for the unifi controller that has its own self-signed
cert and will not accept non-TLS connections. We could generate some
certs, provide them to the unifi controller and to traefik, but this is
easier for now.

Docs: https://doc.traefik.io/traefik/routing/overview/#transport-configuration