### PR TITLE
traefik: Add traefik CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,13 @@ deploy-metallb-secret:
 	$(KUBECFG) -V rand="$$(openssl rand -base64 128)" update manifests/metallb/memberlist.jsonnet
 
 .PHONY: deploy undeploy deploy-metallb-secret
+
+# --- Update CRDs -------------------------------------------------------------
+
+TRAEFIK_HELM_VERSION = v9.12.3
+TRAEFIK_HELM_ARCHIVE = https://github.com/traefik/traefik-helm-chart/archive
+
+update-crds-traefik:
+	curl -sL $(TRAEFIK_HELM_ARCHIVE)/$(TRAEFIK_HELM_VERSION).tar.gz \
+		| tar zxf - -C manifests/traefik --strip-components=2 \
+			--wildcards '*/traefik/crds/*'

--- a/manifests/traefik/12_rbac.yaml
+++ b/manifests/traefik/12_rbac.yaml
@@ -30,6 +30,21 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - middlewares
+      - ingressroutes
+      - traefikservices
+      - ingressroutetcps
+      - ingressrouteudps
+      - tlsoptions
+      - tlsstores
+      - serverstransports
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/traefik/50_configmap.yaml
+++ b/manifests/traefik/50_configmap.yaml
@@ -44,6 +44,7 @@ data:
       internal-http-no-redirect:  # Internal http
         address: ':8080'
     providers:
+      kubernetesCRD: {}
       kubernetesIngress: {}
       file:
         directory: '/config'

--- a/manifests/traefik/crds/ingressroute.yaml
+++ b/manifests/traefik/crds/ingressroute.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressroutes.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: IngressRoute
+    plural: ingressroutes
+    singular: ingressroute
+  scope: Namespaced

--- a/manifests/traefik/crds/ingressroutetcp.yaml
+++ b/manifests/traefik/crds/ingressroutetcp.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressroutetcps.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: IngressRouteTCP
+    plural: ingressroutetcps
+    singular: ingressroutetcp
+  scope: Namespaced

--- a/manifests/traefik/crds/ingressrouteudp.yaml
+++ b/manifests/traefik/crds/ingressrouteudp.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressrouteudps.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: IngressRouteUDP
+    plural: ingressrouteudps
+    singular: ingressrouteudp
+  scope: Namespaced

--- a/manifests/traefik/crds/middlewares.yaml
+++ b/manifests/traefik/crds/middlewares.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: middlewares.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: Middleware
+    plural: middlewares
+    singular: middleware
+  scope: Namespaced

--- a/manifests/traefik/crds/tlsoptions.yaml
+++ b/manifests/traefik/crds/tlsoptions.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlsoptions.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TLSOption
+    plural: tlsoptions
+    singular: tlsoption
+  scope: Namespaced

--- a/manifests/traefik/crds/tlsstores.yaml
+++ b/manifests/traefik/crds/tlsstores.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlsstores.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TLSStore
+    plural: tlsstores
+    singular: tlsstore
+  scope: Namespaced

--- a/manifests/traefik/crds/traefikservices.yaml
+++ b/manifests/traefik/crds/traefikservices.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traefikservices.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TraefikService
+    plural: traefikservices
+    singular: traefikservice
+  scope: Namespaced


### PR DESCRIPTION
Add the CRDs to the cluster so that traefik configurations can be
created that cannot be done with a standard Ingress - in the coming
case, UDP routers.

Unfortunately there is no clear and simple source for the CRDs (they
dont seem to be bundled with traefik itself (I think the CRD yaml is
generated), but they are unaltered in the helm charts (no helm macros in
these manifests). A make rule has been added to update the CRDs. The
version number of the helm chart has nothing do to with the version
number of traefik unfortunately, so you just need to identify the chart
release for the traefik version and update the CRDs from that tag.

The RBAC privs are even worse. I had to cut and paste them from
https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/
and hope it applies to the version I'm running.

Link: https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/