### PR TITLE
traefik: Bump to version 2.4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ deploy-metallb-secret:
 
 # --- Update CRDs -------------------------------------------------------------
 
-TRAEFIK_HELM_VERSION = v9.12.3
+TRAEFIK_HELM_VERSION = v9.17.6
 TRAEFIK_HELM_ARCHIVE = https://github.com/traefik/traefik-helm-chart/archive
 
 update-crds-traefik:

--- a/manifests/traefik/60_deployment.yaml
+++ b/manifests/traefik/60_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: traefik
       containers:
         - name: traefik
-          image: traefik:v2.3.4
+          image: traefik:v2.4.8
           args: 
             - '--configFile=/config/static.yaml'
           securityContext:

--- a/manifests/traefik/crds/serverstransports.yaml
+++ b/manifests/traefik/crds/serverstransports.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstransports.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: ServersTransport
+    plural: serverstransports
+    singular: serverstransport
+  scope: Namespaced


### PR DESCRIPTION
Update the traefik deployment to version 2.4.8. This requires a new CRD
for `ServersTransport`, which required bumping the helm version where
the CRDs can be found to v9.17.6.

There were no changes to the `ClusterRole` - that comes from a webpage
and is not versioned, so when I added the CRDs for 2.3, the web page
must have had the `ClusterRole` for 2.4 as it already had
`ServerTransports`.