### PR TITLE
Add a upgrade target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SYSTEMD_DIR = /etc/systemd/system
 export INSTALL_DIR K3S_DATA_DIR
 
 install: install-k3s install-k3s-links install-systemd install-dirs
+upgrade: install-k3s restart-k3s
 
 install-k3s: $(INSTALL_DIR)/k3s-killall.sh
 	sudo ./scripts/get-k3s
@@ -29,6 +30,9 @@ $(SYSTEMD_DIR)/multi-user.target.wants/k3s@server.service: $(SYSTEMD_DIR)/k3s@.s
 $(SYSTEMD_DIR)/k3s@.service: systemd/k3s@.service
 	sudo install -m 644 -o root -g root $< $@
 	sudo systemctl daemon-reload
+
+restart-k3s:
+	sudo systemctl restart k3s@server
 
 install-dirs:
 	sudo install -d -m 0750 -g adm $(K3S_DATA_DIR)/pv

--- a/scripts/k3s-killall.sh
+++ b/scripts/k3s-killall.sh
@@ -3,7 +3,7 @@
 
 : "${K3S_DATA_DIR:=/var/lib/rancher/k3s}"
 for bin in "${K3S_DATA_DIR}"/data/**/bin/; do
-    [ -d "$bin" ] && export PATH=$PATH:$bin:$bin/aux
+    [ -d "$bin" ] && export PATH="$PATH:$bin:$bin/aux"
 done
 
 set -x


### PR DESCRIPTION
Add a simple `upgrade` target to the Makefile to upgrade k3s. It just
re-runs the `get-k3s` script (which fetches the latest k3s) and restarts
it. It was enough to upgrade from 1.19 to 1.23 with no issues.