### PR TITLE
traefik: Update to v2.6.1

### DIFF
--- a/manifests/traefik/60_deployment.yaml
+++ b/manifests/traefik/60_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: traefik
       containers:
         - name: traefik
-          image: traefik:v2.6.0
+          image: traefik:v2.6.1
           args: 
             - '--configFile=/config/static.yaml'
           securityContext:


### PR DESCRIPTION
Traefik kindly told me via its logs that there was a newer version out.
So upgrade to v2.6.1 from v2.6.0. It seemed easy this time - no CRDs to
update.

Link: https://github.com/traefik/traefik/releases/tag/v2.6.1