### PR TITLE
install: Add secret saving for reinstallation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,25 @@ deploy-metallb-secret:
 
 .PHONY: deploy undeploy deploy-metallb-secret
 
+# --- Secret Saving -----------------------------------------------------------
+
+save-secrets: save-sealed-secrets
+clean-secrets: clean-sealed-secrets
+
+SS_SECRET = manifests/sealed-secrets/01_master.yaml
+
+save-sealed-secrets:
+	$(KUBECTL) get secret -n kube-system \
+		-l sealedsecrets.bitnami.com/sealed-secrets-key \
+		-o yaml \
+		> $(SS_SECRET)
+
+clean-sealed-secrets:
+	shred --zero --remove $(SS_SECRET)
+
+.PHONY: clean-secrets save-secrets
+.PHONY: clean-sealed-secrets save-sealed-secrets
+
 # --- Update CRDs -------------------------------------------------------------
 
 TRAEFIK_HELM_VERSION = v10.14.0

--- a/README.md
+++ b/README.md
@@ -83,6 +83,38 @@ It is protected so that it is only readable by `root` and members of the
 `adm` group. Add yourself to the `adm` group if you want to run
 Kubernetes commands as a regular user.
 
+### Reinstalling
+
+For continuity through an uninstall and install (re-installation) some
+secrets may need to be preserved. Before running `make uninstall` you
+can run `make save-secrets` which will pull secrets from the cluster and
+put it in the manifest directory ready to be installed in the next
+cluster.
+
+The secrets are left unencrypted in the filesystem, so when you are done
+re-installing the cluster, run `make clean-secrets` to remove them.
+
+The full re-install sequence would be (if you install metallb):
+
+    make save-secrets
+    make uninstall
+    make install
+    make deploy-metallb-secret
+    make deploy
+    make clean-secrets
+
+If you don't install metallb:
+    make save-secrets
+    make uninstall
+    make install
+    make deploy-sealed-secrets deploy-cert-manager deploy-traefik
+    make clean-secrets
+
+At this stage, the only secrets saved are the sealed-secrets sealing
+keys. Usually all other secrets are sealed with sealed-secrets, so this
+should be all that needs to be preserved in order to reload existing
+sealed secrets.
+
 ## Service Deployment
 
 ### Installing Tools


### PR DESCRIPTION
Add `save-secrets` and `clean-secrets` make targets to help with
reinstalling a cluster, and document their use in the README.

`make save-secrets` will save the sealed-secrets sealing keys and place
them ready to be reinstalled when running `make
deploy(-sealed-secrets)`, allowing you to uninstall a cluster and
re-install it, and not need to re-seal your secrets in other
deployments.