### PR TITLE
traefik: Upgrade to v2.8.1 from v2.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ clean-sealed-secrets:
 
 # --- Update CRDs -------------------------------------------------------------
 
-TRAEFIK_HELM_VERSION = v10.14.0
+TRAEFIK_HELM_VERSION = v10.24.0
 TRAEFIK_HELM_ARCHIVE = https://github.com/traefik/traefik-helm-chart/archive
 
 update-crds-traefik:

--- a/manifests/traefik/60_deployment.yaml
+++ b/manifests/traefik/60_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: traefik
       containers:
         - name: traefik
-          image: traefik:v2.6.1
+          image: traefik:v2.8.1
           args: 
             - '--configFile=/config/static.yaml'
           securityContext:

--- a/manifests/traefik/crds/ingressroute.yaml
+++ b/manifests/traefik/crds/ingressroute.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: ingressroutes.traefik.containo.us
 spec:
@@ -17,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IngressRoute is an Ingress CRD specification.
+        description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,96 +34,151 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngressRouteSpec is a specification for a IngressRouteSpec
-              resource.
+            description: IngressRouteSpec defines the desired state of IngressRoute.
             properties:
               entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
                 items:
                   type: string
                 type: array
               routes:
+                description: Routes defines the list of routes.
                 items:
-                  description: Route contains the set of routes.
+                  description: Route holds the HTTP route configuration.
                   properties:
                     kind:
+                      description: Kind defines the kind of the route. Rule is the
+                        only supported kind.
                       enum:
                       - Rule
                       type: string
                     match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule'
                       type: string
                     middlewares:
+                      description: 'Middlewares defines the list of references to
+                        Middleware resources. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-middleware'
                       items:
-                        description: MiddlewareRef is a ref to the Middleware resources.
+                        description: MiddlewareRef is a reference to a Middleware
+                          resource.
                         properties:
                           name:
+                            description: Name defines the name of the referenced Middleware
+                              resource.
                             type: string
                           namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Middleware resource.
                             type: string
                         required:
                         - name
                         type: object
                       type: array
                     priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority'
                       type: integer
                     services:
+                      description: Services defines the list of Service. It can contain
+                        any combination of TraefikService and/or reference to a Kubernetes
+                        Service.
                       items:
-                        description: Service defines an upstream to proxy traffic.
+                        description: Service defines an upstream HTTP service to proxy
+                          traffic to.
                         properties:
                           kind:
+                            description: Kind defines the kind of the Service.
                             enum:
                             - Service
                             - TraefikService
                             type: string
                           name:
-                            description: Name is a reference to a Kubernetes Service
-                              object (for a load-balancer of servers), or to a TraefikService
-                              object (service load-balancer, mirroring, etc). The
-                              differentiation between the two is specified in the
-                              Kind field.
+                            description: Name defines the name of the referenced Kubernetes
+                              Service or TraefikService. The differentiation between
+                              the two is specified in the Kind field.
                             type: string
                           namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service or TraefikService.
                             type: string
                           passHostHeader:
+                            description: PassHostHeader defines whether the client
+                              Host header is forwarded to the upstream Kubernetes
+                              Service. By default, passHostHeader is true.
                             type: boolean
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
                             x-kubernetes-int-or-string: true
                           responseForwarding:
-                            description: ResponseForwarding holds configuration for
-                              the forward of the response.
+                            description: ResponseForwarding defines how Traefik forwards
+                              the response from the upstream Kubernetes Service to
+                              the client.
                             properties:
                               flushInterval:
+                                description: 'FlushInterval defines the interval,
+                                  in milliseconds, in between flushes to the client
+                                  while copying the response body. A negative value
+                                  means to flush immediately after each write to the
+                                  client. This configuration is ignored when ReverseProxy
+                                  recognizes a response as a streaming response; for
+                                  such responses, writes are flushed to the client
+                                  immediately. Default: 100ms'
                                 type: string
                             type: object
                           scheme:
+                            description: Scheme defines the scheme to use for the
+                              request to the upstream Kubernetes Service. It defaults
+                              to https when Kubernetes Service port is 443, http otherwise.
                             type: string
                           serversTransport:
+                            description: ServersTransport defines the name of ServersTransport
+                              resource to use. It allows to configure the transport
+                              between Traefik and your servers. Can only be used on
+                              a Kubernetes Service.
                             type: string
                           sticky:
-                            description: Sticky holds the sticky configuration.
+                            description: 'Sticky defines the sticky sessions configuration.
+                              More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
                             properties:
                               cookie:
-                                description: Cookie holds the sticky configuration
-                                  based on cookie.
+                                description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    description: HTTPOnly defines whether the cookie
+                                      can be accessed by client-side APIs, such as
+                                      JavaScript.
                                     type: boolean
                                   name:
+                                    description: Name defines the Cookie name.
                                     type: string
                                   sameSite:
+                                    description: 'SameSite defines the same site policy.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                                     type: string
                                   secure:
+                                    description: Secure defines whether the cookie
+                                      can only be transmitted over an encrypted connection
+                                      (i.e. HTTPS).
                                     type: boolean
                                 type: object
                             type: object
                           strategy:
+                            description: Strategy defines the load balancing strategy
+                              between the servers. RoundRobin is the only supported
+                              value at the moment.
                             type: string
                           weight:
-                            description: Weight should only be specified when Name
-                              references a TraefikService object (and to be precise,
-                              one that embeds a Weighted Round Robin).
+                            description: Weight defines the weight and should only
+                              be specified when Name references a TraefikService object
+                              (and to be precise, one that embeds a Weighted Round
+                              Robin).
                             type: integer
                         required:
                         - name
@@ -133,32 +190,42 @@ spec:
                   type: object
                 type: array
               tls:
-                description: "TLS contains the TLS certificates configuration of the
-                  routes. To enable Let's Encrypt, use an empty TLS struct, e.g. in
-                  YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
-                  # block format"
+                description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls'
                 properties:
                   certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
                     type: string
                   domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main domain name.
                           type: string
                         sans:
+                          description: SANs defines the subject alternative domain
+                            names.
                           items:
                             type: string
                           type: array
                       type: object
                     type: array
                   options:
-                    description: Options is a reference to a TLSOption, that specifies
-                      the parameters of the TLS connection.
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
                     properties:
                       name:
+                        description: 'Name defines the name of the referenced TLSOption.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
                         type: string
                       namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSOption. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
                         type: string
                     required:
                     - name
@@ -168,12 +235,17 @@ spec:
                       Secret to specify the certificate details.
                     type: string
                   store:
-                    description: Store is a reference to a TLSStore, that specifies
-                      the parameters of the TLS store.
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
                     properties:
                       name:
+                        description: 'Name defines the name of the referenced TLSStore.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
                         type: string
                       namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSStore. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
                         type: string
                     required:
                     - name

--- a/manifests/traefik/crds/ingressroutetcp.yaml
+++ b/manifests/traefik/crds/ingressroutetcp.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: ingressroutetcps.traefik.containo.us
 spec:
@@ -17,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IngressRouteTCP is an Ingress CRD specification.
+        description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,56 +34,89 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngressRouteTCPSpec is a specification for a IngressRouteTCPSpec
-              resource.
+            description: IngressRouteTCPSpec defines the desired state of IngressRouteTCP.
             properties:
               entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
                 items:
                   type: string
                 type: array
               routes:
+                description: Routes defines the list of routes.
                 items:
-                  description: RouteTCP contains the set of routes.
+                  description: RouteTCP holds the TCP route configuration.
                   properties:
                     match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule_1'
                       type: string
                     middlewares:
-                      description: Middlewares contains references to MiddlewareTCP
+                      description: Middlewares defines the list of references to MiddlewareTCP
                         resources.
                       items:
                         description: ObjectReference is a generic reference to a Traefik
                           resource.
                         properties:
                           name:
+                            description: Name defines the name of the referenced Traefik
+                              resource.
                             type: string
                           namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Traefik resource.
                             type: string
                         required:
                         - name
                         type: object
                       type: array
+                    priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority_1'
+                      type: integer
                     services:
+                      description: Services defines the list of TCP services.
                       items:
-                        description: ServiceTCP defines an upstream to proxy traffic.
+                        description: ServiceTCP defines an upstream TCP service to
+                          proxy traffic to.
                         properties:
                           name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
                             type: string
                           namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
                             x-kubernetes-int-or-string: true
                           proxyProtocol:
-                            description: ProxyProtocol holds the ProxyProtocol configuration.
+                            description: 'ProxyProtocol defines the PROXY protocol
+                              configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/services/#proxy-protocol'
                             properties:
                               version:
+                                description: Version defines the PROXY Protocol version
+                                  to use.
                                 type: integer
                             type: object
                           terminationDelay:
+                            description: TerminationDelay defines the deadline that
+                              the proxy sets, after one of its connected peers indicates
+                              it has closed the writing capability of its connection,
+                              to close the reading capability as well, hence fully
+                              terminating the connection. It is a duration in milliseconds,
+                              defaulting to 100. A negative value means an infinite
+                              deadline (i.e. the reading capability is never closed).
                             type: integer
                           weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
                             type: integer
                         required:
                         - name
@@ -93,49 +128,67 @@ spec:
                   type: object
                 type: array
               tls:
-                description: "TLSTCP contains the TLS certificates configuration of
-                  the routes. To enable Let's Encrypt, use an empty TLS struct, e.g.
-                  in YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
-                  # block format"
+                description: 'TLS defines the TLS configuration on a layer 4 / TCP
+                  Route. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls_1'
                 properties:
                   certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
                     type: string
                   domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main domain name.
                           type: string
                         sans:
+                          description: SANs defines the subject alternative domain
+                            names.
                           items:
                             type: string
                           type: array
                       type: object
                     type: array
                   options:
-                    description: Options is a reference to a TLSOption, that specifies
-                      the parameters of the TLS connection.
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
                     properties:
                       name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
                         type: string
                       namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
                         type: string
                     required:
                     - name
                     type: object
                   passthrough:
+                    description: Passthrough defines whether a TLS router will terminate
+                      the TLS connection.
                     type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
                     type: string
                   store:
-                    description: Store is a reference to a TLSStore, that specifies
-                      the parameters of the TLS store.
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
                     properties:
                       name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
                         type: string
                       namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
                         type: string
                     required:
                     - name

--- a/manifests/traefik/crds/ingressrouteudp.yaml
+++ b/manifests/traefik/crds/ingressrouteudp.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: ingressrouteudps.traefik.containo.us
 spec:
@@ -17,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IngressRouteUDP is an Ingress CRD specification.
+        description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,31 +34,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngressRouteUDPSpec is a specification for a IngressRouteUDPSpec
-              resource.
+            description: IngressRouteUDPSpec defines the desired state of a IngressRouteUDP.
             properties:
               entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
                 items:
                   type: string
                 type: array
               routes:
+                description: Routes defines the list of routes.
                 items:
-                  description: RouteUDP contains the set of routes.
+                  description: RouteUDP holds the UDP route configuration.
                   properties:
                     services:
+                      description: Services defines the list of UDP services.
                       items:
-                        description: ServiceUDP defines an upstream to proxy traffic.
+                        description: ServiceUDP defines an upstream UDP service to
+                          proxy traffic to.
                         properties:
                           name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
                             type: string
                           namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
                             x-kubernetes-int-or-string: true
                           weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
                             type: integer
                         required:
                         - name

--- a/manifests/traefik/crds/middlewares.yaml
+++ b/manifests/traefik/crds/middlewares.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: middlewares.traefik.containo.us
 spec:
@@ -17,7 +19,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Middleware is a specification for a Middleware resource.
+        description: 'Middleware is the CRD implementation of a Traefik Middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/overview/'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,54 +35,99 @@ spec:
           metadata:
             type: object
           spec:
-            description: MiddlewareSpec holds the Middleware configuration.
+            description: MiddlewareSpec defines the desired state of a Middleware.
             properties:
               addPrefix:
-                description: AddPrefix holds the AddPrefix configuration.
+                description: 'AddPrefix holds the add prefix middleware configuration.
+                  This middleware updates the path of a request before forwarding
+                  it. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/addprefix/'
                 properties:
                   prefix:
+                    description: Prefix is the string to add before the current path
+                      in the requested URL. It should include a leading slash (/).
                     type: string
                 type: object
               basicAuth:
-                description: BasicAuth holds the HTTP basic authentication configuration.
+                description: 'BasicAuth holds the basic auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/'
                 properties:
                   headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
                     type: string
                   realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
                     type: string
                   removeHeader:
+                    description: 'RemoveHeader sets the removeHeader option to true
+                      to remove the authorization header before forwarding the request
+                      to your service. Default: false.'
                     type: boolean
                   secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
                     type: string
                 type: object
               buffering:
-                description: Buffering holds the request/response buffering configuration.
+                description: 'Buffering holds the buffering middleware configuration.
+                  This middleware retries or limits the size of requests that can
+                  be forwarded to backends. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#maxrequestbodybytes'
                 properties:
                   maxRequestBodyBytes:
+                    description: 'MaxRequestBodyBytes defines the maximum allowed
+                      body size for the request (in bytes). If the request exceeds
+                      the allowed size, it is not forwarded to the service, and the
+                      client gets a 413 (Request Entity Too Large) response. Default:
+                      0 (no maximum).'
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    description: 'MaxResponseBodyBytes defines the maximum allowed
+                      response size from the service (in bytes). If the response exceeds
+                      the allowed size, it is not forwarded to the client. The client
+                      gets a 500 (Internal Server Error) response instead. Default:
+                      0 (no maximum).'
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    description: 'MemRequestBodyBytes defines the threshold (in bytes)
+                      from which the request will be buffered on disk instead of in
+                      memory. Default: 1048576 (1Mi).'
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    description: 'MemResponseBodyBytes defines the threshold (in bytes)
+                      from which the response will be buffered on disk instead of
+                      in memory. Default: 1048576 (1Mi).'
                     format: int64
                     type: integer
                   retryExpression:
+                    description: 'RetryExpression defines the retry conditions. It
+                      is a logical combination of functions with operators AND (&&)
+                      and OR (||). More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#retryexpression'
                     type: string
                 type: object
               chain:
-                description: Chain holds a chain of middlewares.
+                description: 'Chain holds the configuration of the chain middleware.
+                  This middleware enables to define reusable combinations of other
+                  pieces of middleware. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/chain/'
                 properties:
                   middlewares:
+                    description: Middlewares is the list of MiddlewareRef which composes
+                      the chain.
                     items:
-                      description: MiddlewareRef is a ref to the Middleware resources.
+                      description: MiddlewareRef is a reference to a Middleware resource.
                       properties:
                         name:
+                          description: Name defines the name of the referenced Middleware
+                            resource.
                           type: string
                         namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Middleware resource.
                           type: string
                       required:
                       - name
@@ -89,161 +137,277 @@ spec:
               circuitBreaker:
                 description: CircuitBreaker holds the circuit breaker configuration.
                 properties:
+                  checkPeriod:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CheckPeriod is the interval between successive checks
+                      of the circuit breaker condition (when in standby state).
+                    x-kubernetes-int-or-string: true
                   expression:
+                    description: Expression is the condition that triggers the tripped
+                      state.
                     type: string
+                  fallbackDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: FallbackDuration is the duration for which the circuit
+                      breaker will wait before trying to recover (from a tripped state).
+                    x-kubernetes-int-or-string: true
+                  recoveryDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: RecoveryDuration is the duration for which the circuit
+                      breaker will try to recover (as soon as it is in recovering
+                      state).
+                    x-kubernetes-int-or-string: true
                 type: object
               compress:
-                description: Compress holds the compress configuration.
+                description: 'Compress holds the compress middleware configuration.
+                  This middleware compresses responses before sending them to the
+                  client, using gzip compression. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/compress/'
                 properties:
                   excludedContentTypes:
+                    description: ExcludedContentTypes defines the list of content
+                      types to compare the Content-Type header of the incoming requests
+                      and responses before compressing.
                     items:
                       type: string
                     type: array
+                  minResponseBodyBytes:
+                    description: 'MinResponseBodyBytes defines the minimum amount
+                      of bytes a response body must have to be compressed. Default:
+                      1024.'
+                    type: integer
                 type: object
               contentType:
-                description: ContentType middleware - or rather its unique `autoDetect`
-                  option - specifies whether to let the `Content-Type` header, if
-                  it has not been set by the backend, be automatically set to a value
-                  derived from the contents of the response. As a proxy, the default
-                  behavior should be to leave the header alone, regardless of what
-                  the backend did with it. However, the historic default was to always
-                  auto-detect and set the header if it was nil, and it is going to
-                  be kept that way in order to support users currently relying on
-                  it. This middleware exists to enable the correct behavior until
-                  at least the default one can be changed in a future version.
+                description: ContentType holds the content-type middleware configuration.
+                  This middleware exists to enable the correct behavior until at least
+                  the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    description: AutoDetect specifies whether to let the `Content-Type`
+                      header, if it has not been set by the backend, be automatically
+                      set to a value derived from the contents of the response. As
+                      a proxy, the default behavior should be to leave the header
+                      alone, regardless of what the backend did with it. However,
+                      the historic default was to always auto-detect and set the header
+                      if it was nil, and it is going to be kept that way in order
+                      to support users currently relying on it.
                     type: boolean
                 type: object
               digestAuth:
-                description: DigestAuth holds the Digest HTTP authentication configuration.
+                description: 'DigestAuth holds the digest auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/digestauth/'
                 properties:
                   headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
                     type: string
                   realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
                     type: string
                   removeHeader:
+                    description: RemoveHeader defines whether to remove the authorization
+                      header before forwarding the request to the backend.
                     type: boolean
                   secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
                     type: string
                 type: object
               errors:
-                description: ErrorPage holds the custom error page configuration.
+                description: 'ErrorPage holds the custom error middleware configuration.
+                  This middleware returns a custom page in lieu of the default, according
+                  to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/'
                 properties:
                   query:
+                    description: Query defines the URL for the error page (hosted
+                      by service). The {status} variable can be used in order to insert
+                      the status code in the URL.
                     type: string
                   service:
-                    description: Service defines an upstream to proxy traffic.
+                    description: 'Service defines the reference to a Kubernetes Service
+                      that will serve the error page. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/#service'
                     properties:
                       kind:
+                        description: Kind defines the kind of the Service.
                         enum:
                         - Service
                         - TraefikService
                         type: string
                       name:
-                        description: Name is a reference to a Kubernetes Service object
-                          (for a load-balancer of servers), or to a TraefikService
-                          object (service load-balancer, mirroring, etc). The differentiation
-                          between the two is specified in the Kind field.
+                        description: Name defines the name of the referenced Kubernetes
+                          Service or TraefikService. The differentiation between the
+                          two is specified in the Kind field.
                         type: string
                       namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Kubernetes Service or TraefikService.
                         type: string
                       passHostHeader:
+                        description: PassHostHeader defines whether the client Host
+                          header is forwarded to the upstream Kubernetes Service.
+                          By default, passHostHeader is true.
                         type: boolean
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Port defines the port of a Kubernetes Service.
+                          This can be a reference to a named port.
                         x-kubernetes-int-or-string: true
                       responseForwarding:
-                        description: ResponseForwarding holds configuration for the
-                          forward of the response.
+                        description: ResponseForwarding defines how Traefik forwards
+                          the response from the upstream Kubernetes Service to the
+                          client.
                         properties:
                           flushInterval:
+                            description: 'FlushInterval defines the interval, in milliseconds,
+                              in between flushes to the client while copying the response
+                              body. A negative value means to flush immediately after
+                              each write to the client. This configuration is ignored
+                              when ReverseProxy recognizes a response as a streaming
+                              response; for such responses, writes are flushed to
+                              the client immediately. Default: 100ms'
                             type: string
                         type: object
                       scheme:
+                        description: Scheme defines the scheme to use for the request
+                          to the upstream Kubernetes Service. It defaults to https
+                          when Kubernetes Service port is 443, http otherwise.
                         type: string
                       serversTransport:
+                        description: ServersTransport defines the name of ServersTransport
+                          resource to use. It allows to configure the transport between
+                          Traefik and your servers. Can only be used on a Kubernetes
+                          Service.
                         type: string
                       sticky:
-                        description: Sticky holds the sticky configuration.
+                        description: 'Sticky defines the sticky sessions configuration.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
                         properties:
                           cookie:
-                            description: Cookie holds the sticky configuration based
-                              on cookie.
+                            description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                description: HTTPOnly defines whether the cookie can
+                                  be accessed by client-side APIs, such as JavaScript.
                                 type: boolean
                               name:
+                                description: Name defines the Cookie name.
                                 type: string
                               sameSite:
+                                description: 'SameSite defines the same site policy.
+                                  More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                                 type: string
                               secure:
+                                description: Secure defines whether the cookie can
+                                  only be transmitted over an encrypted connection
+                                  (i.e. HTTPS).
                                 type: boolean
                             type: object
                         type: object
                       strategy:
+                        description: Strategy defines the load balancing strategy
+                          between the servers. RoundRobin is the only supported value
+                          at the moment.
                         type: string
                       weight:
-                        description: Weight should only be specified when Name references
-                          a TraefikService object (and to be precise, one that embeds
-                          a Weighted Round Robin).
+                        description: Weight defines the weight and should only be
+                          specified when Name references a TraefikService object (and
+                          to be precise, one that embeds a Weighted Round Robin).
                         type: integer
                     required:
                     - name
                     type: object
                   status:
+                    description: Status defines which status or range of statuses
+                      should result in an error page. It can be either a status code
+                      as a number (500), as multiple comma-separated numbers (500,502),
+                      as ranges by separating two codes with a dash (500-599), or
+                      a combination of the two (404,418,500-599).
                     items:
                       type: string
                     type: array
                 type: object
               forwardAuth:
-                description: ForwardAuth holds the http forward authentication configuration.
+                description: 'ForwardAuth holds the forward auth middleware configuration.
+                  This middleware delegates the request authentication to a Service.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/'
                 properties:
                   address:
+                    description: Address defines the authentication server address.
                     type: string
                   authRequestHeaders:
+                    description: AuthRequestHeaders defines the list of the headers
+                      to copy from the request to the authentication server. If not
+                      set or empty then all request headers are passed.
                     items:
                       type: string
                     type: array
                   authResponseHeaders:
+                    description: AuthResponseHeaders defines the list of headers to
+                      copy from the authentication server response and set on forwarded
+                      request, replacing any existing conflicting headers.
                     items:
                       type: string
                     type: array
                   authResponseHeadersRegex:
+                    description: 'AuthResponseHeadersRegex defines the regex to match
+                      headers to copy from the authentication server response and
+                      set on forwarded request, after stripping all headers that match
+                      the regex. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/#authresponseheadersregex'
                     type: string
                   tls:
-                    description: ClientTLS holds TLS specific configurations as client.
+                    description: TLS defines the configuration used to secure the
+                      connection to the authentication server.
                     properties:
                       caOptional:
                         type: boolean
                       caSecret:
+                        description: CASecret is the name of the referenced Kubernetes
+                          Secret containing the CA to validate the server certificate.
+                          The CA certificate is extracted from key `tls.ca` or `ca.crt`.
                         type: string
                       certSecret:
+                        description: CertSecret is the name of the referenced Kubernetes
+                          Secret containing the client certificate. The client certificate
+                          is extracted from the keys `tls.crt` and `tls.key`.
                         type: string
                       insecureSkipVerify:
+                        description: InsecureSkipVerify defines whether the server
+                          certificates should be validated.
                         type: boolean
                     type: object
                   trustForwardHeader:
+                    description: 'TrustForwardHeader defines whether to trust (ie:
+                      forward) all X-Forwarded-* headers.'
                     type: boolean
                 type: object
               headers:
-                description: Headers holds the custom header configuration.
+                description: 'Headers holds the headers middleware configuration.
+                  This middleware manages the requests and responses headers. More
+                  info: https://doc.traefik.io/traefik/v2.8/middlewares/http/headers/#customrequestheaders'
                 properties:
                   accessControlAllowCredentials:
-                    description: AccessControlAllowCredentials is only valid if true.
-                      false is ignored.
+                    description: AccessControlAllowCredentials defines whether the
+                      request can include user credentials.
                     type: boolean
                   accessControlAllowHeaders:
-                    description: AccessControlAllowHeaders must be used in response
-                      to a preflight request with Access-Control-Request-Headers set.
+                    description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
+                      values sent in preflight response.
                     items:
                       type: string
                     type: array
                   accessControlAllowMethods:
-                    description: AccessControlAllowMethods must be used in response
-                      to a preflight request with Access-Control-Request-Method set.
+                    description: AccessControlAllowMethods defines the Access-Control-Request-Method
+                      values sent in preflight response.
                     items:
                       type: string
                     type: array
@@ -260,60 +424,96 @@ spec:
                       type: string
                     type: array
                   accessControlExposeHeaders:
-                    description: AccessControlExposeHeaders sets valid headers for
-                      the response.
+                    description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
+                      values sent in preflight response.
                     items:
                       type: string
                     type: array
                   accessControlMaxAge:
-                    description: AccessControlMaxAge sets the time that a preflight
+                    description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
-                    description: AddVaryHeader controls if the Vary header is automatically
-                      added/updated when the AccessControlAllowOriginList is set.
+                    description: AddVaryHeader defines whether the Vary header is
+                      automatically added/updated when the AccessControlAllowOriginList
+                      is set.
                     type: boolean
                   allowedHosts:
+                    description: AllowedHosts defines the fully qualified list of
+                      allowed domain names.
                     items:
                       type: string
                     type: array
                   browserXssFilter:
+                    description: BrowserXSSFilter defines whether to add the X-XSS-Protection
+                      header with the value 1; mode=block.
                     type: boolean
                   contentSecurityPolicy:
+                    description: ContentSecurityPolicy defines the Content-Security-Policy
+                      header value.
                     type: string
                   contentTypeNosniff:
+                    description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
+                      header with the nosniff value.
                     type: boolean
                   customBrowserXSSValue:
+                    description: CustomBrowserXSSValue defines the X-XSS-Protection
+                      header value. This overrides the BrowserXssFilter option.
                     type: string
                   customFrameOptionsValue:
+                    description: CustomFrameOptionsValue defines the X-Frame-Options
+                      header value. This overrides the FrameDeny option.
                     type: string
                   customRequestHeaders:
                     additionalProperties:
                       type: string
+                    description: CustomRequestHeaders defines the header names and
+                      values to apply to the request.
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
+                    description: CustomResponseHeaders defines the header names and
+                      values to apply to the response.
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    description: ForceSTSHeader defines whether to add the STS header
+                      even when the connection is HTTP.
                     type: boolean
                   frameDeny:
+                    description: FrameDeny defines whether to add the X-Frame-Options
+                      header with the DENY value.
                     type: boolean
                   hostsProxyHeaders:
+                    description: HostsProxyHeaders defines the header keys that may
+                      hold a proxied hostname value for the request.
                     items:
                       type: string
                     type: array
                   isDevelopment:
+                    description: IsDevelopment defines whether to mitigate the unwanted
+                      effects of the AllowedHosts, SSL, and STS options when developing.
+                      Usually testing takes place using HTTP, not HTTPS, and on localhost,
+                      not your production domain. If you would like your development
+                      environment to mimic production with complete Host blocking,
+                      SSL redirects, and STS headers, leave this as false.
                     type: boolean
                   permissionsPolicy:
+                    description: PermissionsPolicy defines the Permissions-Policy
+                      header value. This allows sites to control browser features.
                     type: string
                   publicKey:
+                    description: PublicKey is the public key that implements HPKP
+                      to prevent MITM attacks with forged certificates.
                     type: string
                   referrerPolicy:
+                    description: ReferrerPolicy defines the Referrer-Policy header
+                      value. This allows sites to control whether browsers forward
+                      the Referer header to other sites.
                     type: string
                   sslForceHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -324,6 +524,10 @@ spec:
                   sslProxyHeaders:
                     additionalProperties:
                       type: string
+                    description: 'SSLProxyHeaders defines the header keys with associated
+                      values that would indicate a valid HTTPS request. It can be
+                      useful when using other proxies (example: "X-Forwarded-Proto":
+                      "https").'
                     type: object
                   sslRedirect:
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
@@ -334,217 +538,366 @@ spec:
                       instead.'
                     type: boolean
                   stsIncludeSubdomains:
+                    description: STSIncludeSubdomains defines whether the includeSubDomains
+                      directive is appended to the Strict-Transport-Security header.
                     type: boolean
                   stsPreload:
+                    description: STSPreload defines whether the preload flag is appended
+                      to the Strict-Transport-Security header.
                     type: boolean
                   stsSeconds:
+                    description: STSSeconds defines the max-age of the Strict-Transport-Security
+                      header. If set to 0, the header is not set.
                     format: int64
                     type: integer
                 type: object
               inFlightReq:
-                description: InFlightReq limits the number of requests being processed
-                  and served concurrently.
+                description: 'InFlightReq holds the in-flight request middleware configuration.
+                  This middleware limits the number of requests being processed and
+                  served concurrently. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/'
                 properties:
                   amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      in-flight request. The middleware responds with HTTP 429 Too
+                      Many Requests if there are already amount requests in progress
+                      (based on the same sourceCriterion strategy).
                     format: int64
                     type: integer
                   sourceCriterion:
-                    description: SourceCriterion defines what criterion is used to
-                      group requests as originating from a common source. If none
-                      are set, the default is to use the request's remote address
-                      field. All fields are mutually exclusive.
+                    description: 'SourceCriterion defines what criterion is used to
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the requestHost. More
+                      info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/#sourcecriterion'
                     properties:
                       ipStrategy:
-                        description: IPStrategy holds the ip strategy configuration.
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
                         properties:
                           depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
                             type: integer
                           excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
                             items:
                               type: string
                             type: array
                         type: object
                       requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
                         type: string
                       requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
                         type: boolean
                     type: object
                 type: object
               ipWhiteList:
-                description: IPWhiteList holds the ip white list configuration.
+                description: 'IPWhiteList holds the IP whitelist middleware configuration.
+                  This middleware accepts / refuses requests based on the client IP.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/'
                 properties:
                   ipStrategy:
-                    description: IPStrategy holds the ip strategy configuration.
+                    description: 'IPStrategy holds the IP strategy configuration used
+                      by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
                     properties:
                       depth:
+                        description: Depth tells Traefik to use the X-Forwarded-For
+                          header and take the IP located at the depth position (starting
+                          from the right).
                         type: integer
                       excludedIPs:
+                        description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
+                          header and select the first IP not in the list.
                         items:
                           type: string
                         type: array
                     type: object
                   sourceRange:
+                    description: SourceRange defines the set of allowed IPs (or ranges
+                      of allowed IPs by using CIDR notation).
                     items:
                       type: string
                     type: array
                 type: object
               passTLSClientCert:
-                description: PassTLSClientCert holds the TLS client cert headers configuration.
+                description: 'PassTLSClientCert holds the pass TLS client cert middleware
+                  configuration. This middleware adds the selected data from the passed
+                  client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/passtlsclientcert/'
                 properties:
                   info:
-                    description: TLSClientCertificateInfo holds the client TLS certificate
-                      info configuration.
+                    description: Info selects the specific client certificate details
+                      you want to add to the X-Forwarded-Tls-Client-Cert-Info header.
                     properties:
                       issuer:
-                        description: TLSCLientCertificateDNInfo holds the client TLS
-                          certificate distinguished name info configuration. cf https://tools.ietf.org/html/rfc3739
+                        description: Issuer defines the client certificate issuer
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the issuer.
                             type: boolean
                           country:
+                            description: Country defines whether to add the country
+                              information into the issuer.
                             type: boolean
                           domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the issuer.
                             type: boolean
                           locality:
+                            description: Locality defines whether to add the locality
+                              information into the issuer.
                             type: boolean
                           organization:
+                            description: Organization defines whether to add the organization
+                              information into the issuer.
                             type: boolean
                           province:
+                            description: Province defines whether to add the province
+                              information into the issuer.
                             type: boolean
                           serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the issuer.
                             type: boolean
                         type: object
                       notAfter:
+                        description: NotAfter defines whether to add the Not After
+                          information from the Validity part.
                         type: boolean
                       notBefore:
+                        description: NotBefore defines whether to add the Not Before
+                          information from the Validity part.
                         type: boolean
                       sans:
+                        description: Sans defines whether to add the Subject Alternative
+                          Name information from the Subject Alternative Name part.
                         type: boolean
                       serialNumber:
+                        description: SerialNumber defines whether to add the client
+                          serialNumber information.
                         type: boolean
                       subject:
-                        description: TLSCLientCertificateDNInfo holds the client TLS
-                          certificate distinguished name info configuration. cf https://tools.ietf.org/html/rfc3739
+                        description: Subject defines the client certificate subject
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the subject.
                             type: boolean
                           country:
+                            description: Country defines whether to add the country
+                              information into the subject.
                             type: boolean
                           domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the subject.
                             type: boolean
                           locality:
+                            description: Locality defines whether to add the locality
+                              information into the subject.
                             type: boolean
                           organization:
+                            description: Organization defines whether to add the organization
+                              information into the subject.
+                            type: boolean
+                          organizationalUnit:
+                            description: OrganizationalUnit defines whether to add
+                              the organizationalUnit information into the subject.
                             type: boolean
                           province:
+                            description: Province defines whether to add the province
+                              information into the subject.
                             type: boolean
                           serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the subject.
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    description: PEM sets the X-Forwarded-Tls-Client-Cert header with
+                      the escaped certificate.
                     type: boolean
                 type: object
               plugin:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin defines the middleware plugin configuration.
+                  More info: https://doc.traefik.io/traefik/plugins/'
                 type: object
               rateLimit:
-                description: RateLimit holds the rate limiting configuration for a
-                  given router.
+                description: 'RateLimit holds the rate limit configuration. This middleware
+                  ensures that services will receive a fair amount of requests, and
+                  allows one to define what fair is. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ratelimit/'
                 properties:
                   average:
+                    description: Average is the maximum rate, by default in requests/s,
+                      allowed for the given source. It defaults to 0, which means
+                      no rate limiting. The rate is actually defined by dividing Average
+                      by Period. So for a rate below 1req/s, one needs to define a
+                      Period larger than a second.
                     format: int64
                     type: integer
                   burst:
+                    description: Burst is the maximum number of requests allowed to
+                      arrive in the same arbitrarily small period of time. It defaults
+                      to 1.
                     format: int64
                     type: integer
                   period:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: 'Period, in combination with Average, defines the
+                      actual maximum rate, such as: r = Average / Period. It defaults
+                      to a second.'
                     x-kubernetes-int-or-string: true
                   sourceCriterion:
                     description: SourceCriterion defines what criterion is used to
-                      group requests as originating from a common source. If none
-                      are set, the default is to use the request's remote address
-                      field. All fields are mutually exclusive.
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the request's remote
+                      address field (as an ipStrategy).
                     properties:
                       ipStrategy:
-                        description: IPStrategy holds the ip strategy configuration.
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
                         properties:
                           depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
                             type: integer
                           excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
                             items:
                               type: string
                             type: array
                         type: object
                       requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
                         type: string
                       requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
                         type: boolean
                     type: object
                 type: object
               redirectRegex:
-                description: RedirectRegex holds the redirection configuration.
+                description: 'RedirectRegex holds the redirect regex middleware configuration.
+                  This middleware redirects a request using regex matching and replacement.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectregex/#regex'
                 properties:
                   permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
                     type: boolean
                   regex:
+                    description: Regex defines the regex used to match and capture
+                      elements from the request URL.
                     type: string
                   replacement:
+                    description: Replacement defines how to modify the URL to have
+                      the new target URL.
                     type: string
                 type: object
               redirectScheme:
-                description: RedirectScheme holds the scheme redirection configuration.
+                description: 'RedirectScheme holds the redirect scheme middleware
+                  configuration. This middleware redirects requests from a scheme/port
+                  to another. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectscheme/'
                 properties:
                   permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
                     type: boolean
                   port:
+                    description: Port defines the port of the new URL.
                     type: string
                   scheme:
+                    description: Scheme defines the scheme of the new URL.
                     type: string
                 type: object
               replacePath:
-                description: ReplacePath holds the ReplacePath configuration.
+                description: 'ReplacePath holds the replace path middleware configuration.
+                  This middleware replaces the path of the request URL and store the
+                  original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepath/'
                 properties:
                   path:
+                    description: Path defines the path to use as replacement in the
+                      request URL.
                     type: string
                 type: object
               replacePathRegex:
-                description: ReplacePathRegex holds the ReplacePathRegex configuration.
+                description: 'ReplacePathRegex holds the replace path regex middleware
+                  configuration. This middleware replaces the path of a URL using
+                  regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepathregex/'
                 properties:
                   regex:
+                    description: Regex defines the regular expression used to match
+                      and capture the path from the request URL.
                     type: string
                   replacement:
+                    description: Replacement defines the replacement path format,
+                      which can include captured variables.
                     type: string
                 type: object
               retry:
-                description: Retry holds the retry configuration.
+                description: 'Retry holds the retry middleware configuration. This
+                  middleware reissues requests a given number of times to a backend
+                  server if that server does not reply. As soon as the server answers,
+                  the middleware stops retrying, regardless of the response status.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/retry/'
                 properties:
                   attempts:
+                    description: Attempts defines how many times the request should
+                      be retried.
                     type: integer
                   initialInterval:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: InitialInterval defines the first wait time in the
+                      exponential backoff series. The maximum interval is calculated
+                      as twice the initialInterval. If unspecified, requests will
+                      be retried immediately. The value of initialInterval should
+                      be provided in seconds or as a valid duration format, see https://pkg.go.dev/time#ParseDuration.
                     x-kubernetes-int-or-string: true
                 type: object
               stripPrefix:
-                description: StripPrefix holds the StripPrefix configuration.
+                description: 'StripPrefix holds the strip prefix middleware configuration.
+                  This middleware removes the specified prefixes from the URL path.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefix/'
                 properties:
                   forceSlash:
+                    description: 'ForceSlash ensures that the resulting stripped path
+                      is not the empty string, by replacing it with / when necessary.
+                      Default: true.'
                     type: boolean
                   prefixes:
+                    description: Prefixes defines the prefixes to strip from the request
+                      URL.
                     items:
                       type: string
                     type: array
                 type: object
               stripPrefixRegex:
-                description: StripPrefixRegex holds the StripPrefixRegex configuration.
+                description: 'StripPrefixRegex holds the strip prefix regex middleware
+                  configuration. This middleware removes the matching prefixes from
+                  the URL path. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefixregex/'
                 properties:
                   regex:
+                    description: Regex defines the regular expression to match the
+                      path prefix from the request URL.
                     items:
                       type: string
                     type: array

--- a/manifests/traefik/crds/middlewarestcp.yaml
+++ b/manifests/traefik/crds/middlewarestcp.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: middlewaretcps.traefik.containo.us
 spec:
@@ -17,7 +19,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MiddlewareTCP is a specification for a MiddlewareTCP resource.
+        description: 'MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/overview/'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,12 +35,24 @@ spec:
           metadata:
             type: object
           spec:
-            description: MiddlewareTCPSpec holds the MiddlewareTCP configuration.
+            description: MiddlewareTCPSpec defines the desired state of a MiddlewareTCP.
             properties:
+              inFlightConn:
+                description: InFlightConn defines the InFlightConn middleware configuration.
+                properties:
+                  amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      connections. The middleware closes the connection if there are
+                      already amount connections opened.
+                    format: int64
+                    type: integer
+                type: object
               ipWhiteList:
-                description: TCPIPWhiteList holds the TCP ip white list configuration.
+                description: IPWhiteList defines the IPWhiteList middleware configuration.
                 properties:
                   sourceRange:
+                    description: SourceRange defines the allowed IPs (or ranges of
+                      allowed IPs by using CIDR notation).
                     items:
                       type: string
                     type: array

--- a/manifests/traefik/crds/serverstransports.yaml
+++ b/manifests/traefik/crds/serverstransports.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: serverstransports.traefik.containo.us
 spec:
@@ -17,7 +19,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServersTransport is a specification for a ServersTransport resource.
+        description: 'ServersTransport is the CRD implementation of a ServersTransport.
+          If no serversTransport is specified, the default@internal will be used.
+          The default@internal serversTransport is created from the static configuration.
+          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#serverstransport_1'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,61 +37,81 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServersTransportSpec options to configure communication between
-              Traefik and the servers.
+            description: ServersTransportSpec defines the desired state of a ServersTransport.
             properties:
               certificatesSecrets:
-                description: Certificates for mTLS.
+                description: CertificatesSecrets defines a list of secret storing
+                  client certificates for mTLS.
                 items:
                   type: string
                 type: array
               disableHTTP2:
-                description: Disable HTTP/2 for connections with backend servers.
+                description: DisableHTTP2 disables HTTP/2 for connections with backend
+                  servers.
                 type: boolean
               forwardingTimeouts:
-                description: Timeouts for requests forwarded to the backend servers.
+                description: ForwardingTimeouts defines the timeouts for requests
+                  forwarded to the backend servers.
                 properties:
                   dialTimeout:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: The amount of time to wait until a connection to
-                      a backend server can be established. If zero, no timeout exists.
+                    description: DialTimeout is the amount of time to wait until a
+                      connection to a backend server can be established.
                     x-kubernetes-int-or-string: true
                   idleConnTimeout:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: The maximum period for which an idle HTTP keep-alive
-                      connection will remain open before closing itself.
+                    description: IdleConnTimeout is the maximum period for which an
+                      idle HTTP keep-alive connection will remain open before closing
+                      itself.
+                    x-kubernetes-int-or-string: true
+                  pingTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: PingTimeout is the timeout after which the HTTP/2
+                      connection will be closed if a response to ping is not received.
+                    x-kubernetes-int-or-string: true
+                  readIdleTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ReadIdleTimeout is the timeout after which a health
+                      check using ping frame will be carried out if no frame is received
+                      on the HTTP/2 connection.
                     x-kubernetes-int-or-string: true
                   responseHeaderTimeout:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: The amount of time to wait for a server's response
-                      headers after fully writing the request (including its body,
-                      if any). If zero, no timeout exists.
+                    description: ResponseHeaderTimeout is the amount of time to wait
+                      for a server's response headers after fully writing the request
+                      (including its body, if any).
                     x-kubernetes-int-or-string: true
                 type: object
               insecureSkipVerify:
-                description: Disable SSL certificate verification.
+                description: InsecureSkipVerify disables SSL certificate verification.
                 type: boolean
               maxIdleConnsPerHost:
-                description: If non-zero, controls the maximum idle (keep-alive) to
-                  keep per-host. If zero, DefaultMaxIdleConnsPerHost is used.
+                description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
+                  to keep per-host.
                 type: integer
               peerCertURI:
-                description: Defines the URI used to match against SAN URIs during
-                  the server's certificate verification.
+                description: PeerCertURI defines the peer cert URI used to match against
+                  SAN URI during the peer certificate verification.
                 type: string
               rootCAsSecrets:
-                description: Add cert file for self-signed certificate.
+                description: RootCAsSecrets defines a list of CA secret used to validate
+                  self-signed certificate.
                 items:
                   type: string
                 type: array
               serverName:
-                description: ServerName used to contact the server.
+                description: ServerName defines the server name used to contact the
+                  server.
                 type: string
             type: object
         required:

--- a/manifests/traefik/crds/tlsoptions.yaml
+++ b/manifests/traefik/crds/tlsoptions.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: tlsoptions.traefik.containo.us
 spec:
@@ -17,7 +19,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TLSOption is a specification for a TLSOption resource.
+        description: 'TLSOption is the CRD implementation of a Traefik TLS Option,
+          allowing to configure some parameters of the TLS connection. More info:
+          https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,19 +36,24 @@ spec:
           metadata:
             type: object
           spec:
-            description: TLSOptionSpec configures TLS for an entry point.
+            description: TLSOptionSpec defines the desired state of a TLSOption.
             properties:
               alpnProtocols:
+                description: 'ALPNProtocols defines the list of supported application
+                  level protocols for the TLS handshake, in order of preference. More
+                  info: https://doc.traefik.io/traefik/v2.8/https/tls/#alpn-protocols'
                 items:
                   type: string
                 type: array
               cipherSuites:
+                description: 'CipherSuites defines the list of supported cipher suites
+                  for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#cipher-suites'
                 items:
                   type: string
                 type: array
               clientAuth:
-                description: ClientAuth defines the parameters of the client authentication
-                  part of the TLS connection, if any.
+                description: ClientAuth defines the server's policy for TLS Client
+                  Authentication.
                 properties:
                   clientAuthType:
                     description: ClientAuthType defines the client authentication
@@ -57,23 +66,36 @@ spec:
                     - RequireAndVerifyClientCert
                     type: string
                   secretNames:
-                    description: SecretName is the name of the referenced Kubernetes
-                      Secret to specify the certificate details.
+                    description: SecretNames defines the names of the referenced Kubernetes
+                      Secret storing certificate details.
                     items:
                       type: string
                     type: array
                 type: object
               curvePreferences:
+                description: 'CurvePreferences defines the preferred elliptic curves
+                  in a specific order. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#curve-preferences'
                 items:
                   type: string
                 type: array
               maxVersion:
+                description: 'MaxVersion defines the maximum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: None.'
                 type: string
               minVersion:
+                description: 'MinVersion defines the minimum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: VersionTLS10.'
                 type: string
               preferServerCipherSuites:
+                description: PreferServerCipherSuites defines whether the server chooses
+                  a cipher suite among his own instead of among the client's. It is
+                  enabled automatically when minVersion or maxVersion are set.
                 type: boolean
               sniStrict:
+                description: SniStrict defines whether Traefik allows connections
+                  from clients connections that do not specify a server_name extension.
                 type: boolean
             type: object
         required:

--- a/manifests/traefik/crds/tlsstores.yaml
+++ b/manifests/traefik/crds/tlsstores.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: tlsstores.traefik.containo.us
 spec:
@@ -17,7 +19,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TLSStore is a specification for a TLSStore resource.
+        description: 'TLSStore is the CRD implementation of a Traefik TLS Store. For
+          the time being, only the TLSStore named default is supported. This means
+          that you cannot have two stores that are named default in different Kubernetes
+          namespaces. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#certificates-stores'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,11 +37,24 @@ spec:
           metadata:
             type: object
           spec:
-            description: TLSStoreSpec configures a TLSStore resource.
+            description: TLSStoreSpec defines the desired state of a TLSStore.
             properties:
+              certificates:
+                description: Certificates is a list of secret names, each secret holding
+                  a key/certificate pair to add to the store.
+                items:
+                  description: Certificate holds a secret name for the TLSStore resource.
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the referenced Kubernetes
+                        Secret to specify the certificate details.
+                      type: string
+                  required:
+                  - secretName
+                  type: object
+                type: array
               defaultCertificate:
-                description: DefaultCertificate holds a secret name for the TLSOption
-                  resource.
+                description: DefaultCertificate defines the default certificate configuration.
                 properties:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
@@ -45,8 +63,6 @@ spec:
                 required:
                 - secretName
                 type: object
-            required:
-            - defaultCertificate
             type: object
         required:
         - metadata

--- a/manifests/traefik/crds/traefikservices.yaml
+++ b/manifests/traefik/crds/traefikservices.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: traefikservices.traefik.containo.us
 spec:
@@ -17,10 +19,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TraefikService is the specification for a service (that an IngressRoute
-          refers to) that is usually not a terminal service (i.e. not a pod of servers),
-          as opposed to a Kubernetes Service. That is to say, it usually refers to
-          other (children) services, which themselves can be TraefikServices or Services.
+        description: 'TraefikService is the CRD implementation of a Traefik Service.
+          TraefikService object allows to:  - Apply weight to Services on load-balancing  -
+          Mirror traffic on services More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-traefikservice'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,220 +36,332 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceSpec defines whether a TraefikService is a load-balancer
-              of services or a mirroring service.
+            description: TraefikServiceSpec defines the desired state of a TraefikService.
             properties:
               mirroring:
-                description: Mirroring defines a mirroring service, which is composed
-                  of a main load-balancer, and a list of mirrors.
+                description: Mirroring defines the Mirroring service configuration.
                 properties:
                   kind:
+                    description: Kind defines the kind of the Service.
                     enum:
                     - Service
                     - TraefikService
                     type: string
                   maxBodySize:
+                    description: MaxBodySize defines the maximum size allowed for
+                      the body of the request. If the body is larger, the request
+                      is not mirrored. Default value is -1, which means unlimited
+                      size.
                     format: int64
                     type: integer
                   mirrors:
+                    description: Mirrors defines the list of mirrors where Traefik
+                      will duplicate the traffic.
                     items:
-                      description: MirrorService defines one of the mirrors of a Mirroring
-                        service.
+                      description: MirrorService holds the mirror configuration.
                       properties:
                         kind:
+                          description: Kind defines the kind of the Service.
                           enum:
                           - Service
                           - TraefikService
                           type: string
                         name:
-                          description: Name is a reference to a Kubernetes Service
-                            object (for a load-balancer of servers), or to a TraefikService
-                            object (service load-balancer, mirroring, etc). The differentiation
-                            between the two is specified in the Kind field.
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
                           type: string
                         namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
                           type: string
                         passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
                           type: boolean
                         percent:
+                          description: 'Percent defines the part of the traffic to
+                            mirror. Supported values: 0 to 100.'
                           type: integer
                         port:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
                           x-kubernetes-int-or-string: true
                         responseForwarding:
-                          description: ResponseForwarding holds configuration for
-                            the forward of the response.
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
                           properties:
                             flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
                               type: string
                           type: object
                         scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
                           type: string
                         serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
                           type: string
                         sticky:
-                          description: Sticky holds the sticky configuration.
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
                           properties:
                             cookie:
-                              description: Cookie holds the sticky configuration based
-                                on cookie.
+                              description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
                                   type: boolean
                                 name:
+                                  description: Name defines the Cookie name.
                                   type: string
                                 sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                                   type: string
                                 secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
                                   type: boolean
                               type: object
                           type: object
                         strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
                           type: string
                         weight:
-                          description: Weight should only be specified when Name references
-                            a TraefikService object (and to be precise, one that embeds
-                            a Weighted Round Robin).
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
                           type: integer
                       required:
                       - name
                       type: object
                     type: array
                   name:
-                    description: Name is a reference to a Kubernetes Service object
-                      (for a load-balancer of servers), or to a TraefikService object
-                      (service load-balancer, mirroring, etc). The differentiation
-                      between the two is specified in the Kind field.
+                    description: Name defines the name of the referenced Kubernetes
+                      Service or TraefikService. The differentiation between the two
+                      is specified in the Kind field.
                     type: string
                   namespace:
+                    description: Namespace defines the namespace of the referenced
+                      Kubernetes Service or TraefikService.
                     type: string
                   passHostHeader:
+                    description: PassHostHeader defines whether the client Host header
+                      is forwarded to the upstream Kubernetes Service. By default,
+                      passHostHeader is true.
                     type: boolean
                   port:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: Port defines the port of a Kubernetes Service. This
+                      can be a reference to a named port.
                     x-kubernetes-int-or-string: true
                   responseForwarding:
-                    description: ResponseForwarding holds configuration for the forward
-                      of the response.
+                    description: ResponseForwarding defines how Traefik forwards the
+                      response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        description: 'FlushInterval defines the interval, in milliseconds,
+                          in between flushes to the client while copying the response
+                          body. A negative value means to flush immediately after
+                          each write to the client. This configuration is ignored
+                          when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms'
                         type: string
                     type: object
                   scheme:
+                    description: Scheme defines the scheme to use for the request
+                      to the upstream Kubernetes Service. It defaults to https when
+                      Kubernetes Service port is 443, http otherwise.
                     type: string
                   serversTransport:
+                    description: ServersTransport defines the name of ServersTransport
+                      resource to use. It allows to configure the transport between
+                      Traefik and your servers. Can only be used on a Kubernetes Service.
                     type: string
                   sticky:
-                    description: Sticky holds the sticky configuration.
+                    description: 'Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
                     properties:
                       cookie:
-                        description: Cookie holds the sticky configuration based on
-                          cookie.
+                        description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
                             type: boolean
                           name:
+                            description: Name defines the Cookie name.
                             type: string
                           sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                             type: string
                           secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
                             type: boolean
                         type: object
                     type: object
                   strategy:
+                    description: Strategy defines the load balancing strategy between
+                      the servers. RoundRobin is the only supported value at the moment.
                     type: string
                   weight:
-                    description: Weight should only be specified when Name references
-                      a TraefikService object (and to be precise, one that embeds
-                      a Weighted Round Robin).
+                    description: Weight defines the weight and should only be specified
+                      when Name references a TraefikService object (and to be precise,
+                      one that embeds a Weighted Round Robin).
                     type: integer
                 required:
                 - name
                 type: object
               weighted:
-                description: WeightedRoundRobin defines a load-balancer of services.
+                description: Weighted defines the Weighted Round Robin configuration.
                 properties:
                   services:
+                    description: Services defines the list of Kubernetes Service and/or
+                      TraefikService to load-balance, with weight.
                     items:
-                      description: Service defines an upstream to proxy traffic.
+                      description: Service defines an upstream HTTP service to proxy
+                        traffic to.
                       properties:
                         kind:
+                          description: Kind defines the kind of the Service.
                           enum:
                           - Service
                           - TraefikService
                           type: string
                         name:
-                          description: Name is a reference to a Kubernetes Service
-                            object (for a load-balancer of servers), or to a TraefikService
-                            object (service load-balancer, mirroring, etc). The differentiation
-                            between the two is specified in the Kind field.
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
                           type: string
                         namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
                           type: string
                         passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
                           type: boolean
                         port:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
                           x-kubernetes-int-or-string: true
                         responseForwarding:
-                          description: ResponseForwarding holds configuration for
-                            the forward of the response.
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
                           properties:
                             flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
                               type: string
                           type: object
                         scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
                           type: string
                         serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
                           type: string
                         sticky:
-                          description: Sticky holds the sticky configuration.
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
                           properties:
                             cookie:
-                              description: Cookie holds the sticky configuration based
-                                on cookie.
+                              description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
                                   type: boolean
                                 name:
+                                  description: Name defines the Cookie name.
                                   type: string
                                 sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                                   type: string
                                 secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
                                   type: boolean
                               type: object
                           type: object
                         strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
                           type: string
                         weight:
-                          description: Weight should only be specified when Name references
-                            a TraefikService object (and to be precise, one that embeds
-                            a Weighted Round Robin).
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
                           type: integer
                       required:
                       - name
                       type: object
                     type: array
                   sticky:
-                    description: Sticky holds the sticky configuration.
+                    description: 'Sticky defines whether sticky sessions are enabled.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#stickiness-and-load-balancing'
                     properties:
                       cookie:
-                        description: Cookie holds the sticky configuration based on
-                          cookie.
+                        description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
                             type: boolean
                           name:
+                            description: Name defines the Cookie name.
                             type: string
                           sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                             type: string
                           secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
                             type: boolean
                         type: object
                     type: object


### PR DESCRIPTION
Upgrade traefik to v2.8.1 just to keep up-to-date.

This is the usual traefik shitfest for upgrading, and I have skipped the
intermediate 2.7.X series as the only point of including the
intermediates is to be able to see what has changed in incremental
steps. But in this case, 2.7.X did a bunch of whitespace changes to the
CRDs which were reverted for 2.8.X, so it's all just noise.

Usual upgrade process:
* Pick version (2.8.1) (link 1)
* Update image tag in `60_deployment.yaml`
* Find the helm chart release corresponding to traefik version (link 2)
* Update Makefile with that version
* Run: `make update-crds-traefik`
* Copy RBAC config from web page (link 3)
* Update the name/namespace for ServiceAccount subject to be
  traefik/traefik to match my deployment
* Deploy with: `make deploy-traefik`

Link: https://github.com/traefik/traefik/releases
Link: https://github.com/traefik/traefik-helm-chart/commits/master
Link: https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/#rbac